### PR TITLE
Modify TMP value for all deployments

### DIFF
--- a/bicep/modules/azure-openai.bicep
+++ b/bicep/modules/azure-openai.bicep
@@ -46,7 +46,7 @@ resource deployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01
   parent: azureOpenAI
   sku: {
     name: 'Standard'
-    capacity: 1
+    capacity: 100
   }
   name: deployment.name
   properties: {


### PR DESCRIPTION
AOAI deployments were created with a low TMP rate, causing frequent 429 throttling error.  This changes the bicep to deploy the models with a 100K rate